### PR TITLE
Added initial dictionary for translation, fixes #9

### DIFF
--- a/support/dictionary.md
+++ b/support/dictionary.md
@@ -25,6 +25,12 @@
       <td>Semantic Versioning</td> <td>תיוג סמנטי</td> <td></td>
     </tr>
     <tr>
+      <td>Major version</td> <td>גירסה מג'ורית</td> <td></td>
+    </tr>
+    <tr>
+      <td>Minor version</td> <td>גירסה מינורית</td> <td></td>
+    </tr>
+    <tr>
       <td>Open Governance</td> <td>ניהול פתוח</td> <td>* לדעתי, ממשל פחות רלוונטי במקרה הנ"ל, ולכן עדיף השימוש בניהול.</td>
     </tr>
     <tr>
@@ -39,6 +45,13 @@
     <tr>
       <td>Event Loop</td> <td>"לולאת ארועים"</td> <td></td>
     </tr>
+    <tr>
+      <td>Streams</td> <td>זרמים? נחשולים?</td> <td></td>
+    </tr>
+    <tr>
+      <td>Roadmap</td> <td>מפת דרכים</td> <td></td>
+    </tr>
+
   </tbody>
 </table>
 

--- a/support/dictionary.md
+++ b/support/dictionary.md
@@ -1,0 +1,48 @@
+<div dir="rtl" lang="he">
+
+מטרת הטבלה שלהלן היא לצמצם את המאמץ המוחי הנגזר מנסיון לתרגם את המונחים הטכניים הנפוצים והחוזרים על עצמם במסמכים השונים הנגזרים מהסביבה של «IOJS».
+המתנדבים השונים והחביבים, נא הרגישו חופשי להוסיף להאיר ולהעיר.
+
+
+<h2>
+טבלת תרגומים נפוצים
+</h2>
+
+<table border="1">
+  <thead>
+      <th>אנגלית</th>
+      <th>עברית</th>
+      <th>הערות</th>
+  </thead>
+  <tbody>
+    <tr>
+      <td>JavaScript</td> <td>ג'אווה סקריפט</td> <td></td>
+    </tr>
+    <tr>
+      <td>Feature</td> <td>תכונה</td> <td></td>
+    </tr>
+    <tr>
+      <td>Semantic Versioning</td> <td>תיוג סמנטי</td> <td></td>
+    </tr>
+    <tr>
+      <td>Open Governance</td> <td>ניהול פתוח</td> <td>* לדעתי, ממשל פחות רלוונטי במקרה הנ"ל, ולכן עדיף השימוש בניהול.</td>
+    </tr>
+    <tr>
+      <td>Promise</td> <td>"פונקציית הבטחה"</td> <td></td>
+    </tr>
+    <tr>
+      <td>Async/Asynchronous</td> <td>א-סינכרוני / א-סינכרוניות</td> <td></td>
+    </tr>
+    <tr>
+      <td>Function</td> <td>פונקציה</td> <td>* אישית, אני מעדיף על פני תרגומים כמו שיטה או שגרה.</td>
+    </tr>
+    <tr>
+      <td>Event Loop</td> <td>"לולאת ארועים"</td> <td></td>
+    </tr>
+  </tbody>
+</table>
+
+</div>
+
+
+


### PR DESCRIPTION
This is really just an initial set of translations.
Feel free to add whatever else might be missing.

For what it's worth, I opted for an html table rather than MD one, because it seems like markdown table + rtl is all messed up.
